### PR TITLE
bug: don't overwrite pod5 manifest on split runs

### DIFF
--- a/mingo/uploader.py
+++ b/mingo/uploader.py
@@ -201,7 +201,6 @@ class MingoUploader:
 
     def write_manifest(self, top_run_dir, run_name, manifest_type, manifest_data, order_name=None, s3_bucket=None):
         """Writes a JSON manifest of uploaded files and optionally uploads it to S3."""
-        # Check if manifest data is valid before writing
         if not manifest_data:
             return None
             
@@ -209,6 +208,29 @@ class MingoUploader:
             manifest_filename = f"manifest_{manifest_type}_{order_name}.json"
         else:
             manifest_filename = f"manifest_{manifest_type}_{run_name}.json"
+            
+        if manifest_type == "pod5" and order_name and s3_bucket:
+            prefix = f"{self.s3_root_folder}/" if self.s3_root_folder else ""
+            dest_key = f"{prefix}{order_name}/{manifest_filename}"
+            bucket_name, dest_key = self._split_bucket_prefix(s3_bucket, dest_key)
+            
+            try:
+                response = self.s3_client.get_object(Bucket=bucket_name, Key=dest_key)
+                existing_data = json.loads(response['Body'].read().decode('utf-8'))
+                
+                # Merge existing URIs with new ones
+                if isinstance(existing_data, list):
+                    existing_uris = {item.get('s3_uri') for item in existing_data if isinstance(item, dict)}
+                    for item in manifest_data:
+                        if item.get('s3_uri') not in existing_uris:
+                            existing_data.append(item)
+                    manifest_data = existing_data
+                    logger.info(f"Merged new uploads with existing manifest {dest_key}")
+            except ClientError as e:
+                if e.response['Error']['Code'] not in ['NoSuchKey', '404']:
+                    logger.warning(f"Failed to fetch existing manifest {dest_key}, proceeding with override: {e}")
+            except Exception as e:
+                logger.warning(f"Failed to parse existing manifest {dest_key}, proceeding with override: {e}")
             
         manifest_path = os.path.join(top_run_dir, manifest_filename)
         


### PR DESCRIPTION
- [x] This PR is ready for review!
  - [x] There are no new testing gaps (coverage has *not* gone down).
  - [ ] This change has had sufficient user-acceptance-testing.
  - [x] All new work is documented (inc the README).
  - [x] This code will deploy safely with all build and test steps automated and documented (static compilations, migrations, config changes, version bumps, etc).
  - [x] There are no debug statements or settings, or critical TODOs left in.
  - [x] This change introduces no security gaps.
  - [x] This change introduces no privacy or other compliance gaps.
  - [x] This change will cause no unplanned performance regressions.
  - [x] This change introduces no unplanned technical debt or unfinished/unrelated work.
  - [x] This change satisfies the change management policy and where needed has been signed off by the relevant project stakeholders.
  - [x] No secrets or other sensitive data (passwords, access keys, PII, etc) are present in **any** of the constituent commits (not just in the final PR).

**What does this Pull Request do and why??**

 - Detects existing POD5 manifests, and merges new file manifest with old if one exists in `mingo-upload`

**What are the relevant Github Issues or support tickets?**
#7 

**Where should the reviewer start?**

Check the logic in uploader.py for detection existing manifests.

**How can the reviewer see this in action and/or test?**

TODO

**Compliance**
Are there security, data protection and privacy considerations that need special attention? (If no, that means you are confident we meet our commitments.)

New POD5s and/or manifests will have different s3 policy expiry dates and the whole project may need manual storage class updates when the second half of a project is upload - TBD (solution is probably to just make expiry a bit longer but not tell customer!)